### PR TITLE
string key encoding and decoding

### DIFF
--- a/src/State.sol
+++ b/src/State.sol
@@ -64,10 +64,7 @@ library CompoundKeyEncoder {
     }
 
     function STRING(bytes4 kindID, string memory id) internal pure returns (bytes24) {
-        return bytes24(abi.encodePacked(
-            kindID,
-            id
-        ));
+        return bytes24(abi.encodePacked(kindID, id));
     }
 }
 
@@ -125,13 +122,13 @@ library CompoundKeyDecoder {
         while (len < 20 && id[4 + len] != 0) {
             len++;
         }
-        
+
         // Copy string bytes
         bytes memory stringBytes = new bytes(len);
         for (uint8 i = 0; i < len; i++) {
             stringBytes[i] = id[4 + i];
         }
-        
+
         return string(stringBytes);
     }
 }

--- a/src/State.sol
+++ b/src/State.sol
@@ -62,6 +62,13 @@ library CompoundKeyEncoder {
     function ADDRESS(bytes4 kindID, address addr) internal pure returns (bytes24) {
         return bytes24(abi.encodePacked(kindID, uint160(addr)));
     }
+
+    function STRING(bytes4 kindID, string memory id) internal pure returns (bytes24) {
+        return bytes24(abi.encodePacked(
+            kindID,
+            id
+        ));
+    }
 }
 
 library CompoundKeyDecoder {
@@ -110,6 +117,22 @@ library CompoundKeyDecoder {
 
     function ADDRESS(bytes24 id) internal pure returns (address) {
         return address(uint160(uint192(id)));
+    }
+
+    function STRING(bytes24 id) internal pure returns (string memory) {
+        // Find string length. Keys are fixed at 20 bytes so treat first 0 as null terminator
+        uint8 len;
+        while (len < 20 && id[4 + len] != 0) {
+            len++;
+        }
+        
+        // Copy string bytes
+        bytes memory stringBytes = new bytes(len);
+        for (uint8 i = 0; i < len; i++) {
+            stringBytes[i] = id[4 + i];
+        }
+        
+        return string(stringBytes);
     }
 }
 

--- a/test/KeyEncodeDecode.t.sol
+++ b/test/KeyEncodeDecode.t.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+
+import {State, CompoundKeyEncoder, CompoundKeyDecoder} from "../src/State.sol";
+
+interface Kind {
+    function Item() external;
+}
+
+contract KeyEncodeDecodeTest is Test {
+    function testStringKey() public {
+        // Test strings under 20 chars
+        string memory testKey = "0123456789"; 
+        bytes24 encodedKey = CompoundKeyEncoder.STRING(Kind.Item.selector, testKey);
+        string memory decodedKey = CompoundKeyDecoder.STRING(encodedKey);
+
+        assertEq(
+            decodedKey,
+            testKey,
+            "expected decoded key to equal original key"
+        );
+
+        // Test strings that are 20 chars. 
+        testKey = "01234567890123456789";  
+        encodedKey = CompoundKeyEncoder.STRING(Kind.Item.selector, testKey);
+        decodedKey = CompoundKeyDecoder.STRING(encodedKey);
+
+        assertEq(
+            decodedKey,
+            testKey,
+            "expected decoded key to equal original key"
+        );
+
+        // Test strings that are over 20 chars (Expected to truncate the key) 
+        testKey = "012345678901234567890123456789";
+        encodedKey = CompoundKeyEncoder.STRING(Kind.Item.selector, testKey);
+        decodedKey = CompoundKeyDecoder.STRING(encodedKey);
+
+        string memory testKeyTruncated = "01234567890123456789"; 
+        assertEq(
+            decodedKey,
+            testKeyTruncated,
+            "expected decoded key to equal truncated 20 char key"
+        );
+    }
+}

--- a/test/KeyEncodeDecode.t.sol
+++ b/test/KeyEncodeDecode.t.sol
@@ -12,37 +12,25 @@ interface Kind {
 contract KeyEncodeDecodeTest is Test {
     function testStringKey() public {
         // Test strings under 20 chars
-        string memory testKey = "0123456789"; 
+        string memory testKey = "0123456789";
         bytes24 encodedKey = CompoundKeyEncoder.STRING(Kind.Item.selector, testKey);
         string memory decodedKey = CompoundKeyDecoder.STRING(encodedKey);
 
-        assertEq(
-            decodedKey,
-            testKey,
-            "expected decoded key to equal original key"
-        );
+        assertEq(decodedKey, testKey, "expected decoded key to equal original key");
 
-        // Test strings that are 20 chars. 
-        testKey = "01234567890123456789";  
+        // Test strings that are 20 chars.
+        testKey = "01234567890123456789";
         encodedKey = CompoundKeyEncoder.STRING(Kind.Item.selector, testKey);
         decodedKey = CompoundKeyDecoder.STRING(encodedKey);
 
-        assertEq(
-            decodedKey,
-            testKey,
-            "expected decoded key to equal original key"
-        );
+        assertEq(decodedKey, testKey, "expected decoded key to equal original key");
 
-        // Test strings that are over 20 chars (Expected to truncate the key) 
+        // Test strings that are over 20 chars (Expected to truncate the key)
         testKey = "012345678901234567890123456789";
         encodedKey = CompoundKeyEncoder.STRING(Kind.Item.selector, testKey);
         decodedKey = CompoundKeyDecoder.STRING(encodedKey);
 
-        string memory testKeyTruncated = "01234567890123456789"; 
-        assertEq(
-            decodedKey,
-            testKeyTruncated,
-            "expected decoded key to equal truncated 20 char key"
-        );
+        string memory testKeyTruncated = "01234567890123456789";
+        assertEq(decodedKey, testKeyTruncated, "expected decoded key to equal truncated 20 char key");
     }
 }


### PR DESCRIPTION
# What

- Strings are encoded as fixed 20 character strings
- When strings are decoded the length is found by either finding the first 0 byte in the 20 byte key or if we reach the end of the byte array

# Why

We want to use string IDs for items. 

# Notes

The length finding process might seem a bit fussy but I did this so we don't have to pad all our ID strings to be 20 characters for the decoded string to match the supplied string. If it's not a problem that the decoded version of the string is padded to 20 bytes then gas could be saved by not worrying about finding the length and copying the bytes into memory e.g you can get away with doing just this:

```
function STRING(bytes24 id) internal pure returns (string memory) {
    uint160 key = uint160(uint192(id) & type(uint160).max);
    return string(abi.encodePacked(key));
}
``` 
I didn't find a smoother way of doing this as annoyingly ranges like `[4:] ` aren't supported for `bytes24`
I might have missed something so if you know how to do it, I'd like to know!