### PR TITLE
Node annotations

### DIFF
--- a/src/Dispatcher.sol
+++ b/src/Dispatcher.sol
@@ -166,11 +166,7 @@ contract BaseDispatcher is Dispatcher {
     }
 
     function dispatch(bytes calldata action) public {
-        Context memory ctx = Context({
-            sender: msg.sender,
-            scopes: SCOPE_FULL_ACCESS,
-            clock: uint32(block.number)
-        });
+        Context memory ctx = Context({sender: msg.sender, scopes: SCOPE_FULL_ACCESS, clock: uint32(block.number)});
         this.dispatch(action, ctx);
     }
 

--- a/src/Dispatcher.sol
+++ b/src/Dispatcher.sol
@@ -62,7 +62,7 @@ interface Dispatcher {
 // They might be a seperate contract or an extension of the Dispatcher
 // A "bundle" here means; one or more actions all signed by the same session key
 interface Router {
-    function dispatch(bytes[][] calldata actionBundles, bytes[] calldata sig) external;
+    function dispatch(bytes[][] calldata actionBundles, bytes[] calldata bundleSignatures) external;
 
     function authorizeAddr(Dispatcher dispatcher, uint32 ttl, uint32 scopes, address addr) external;
 

--- a/src/Dispatcher.sol
+++ b/src/Dispatcher.sol
@@ -51,17 +51,18 @@ interface Dispatcher {
     // session data should be considered untrusted and implementations MUST
     // verify the session data or the sender before executing Rules.
     function dispatch(bytes calldata action, Context calldata ctx) external;
-    function dispatch(bytes[] calldata action, Context calldata ctx) external;
+    function dispatch(bytes[] calldata actions, Context calldata ctx) external;
 
     // same as dispatch above, but ctx is built from msg.sender
-    function dispatch(bytes calldata actions) external;
+    function dispatch(bytes calldata action) external;
     function dispatch(bytes[] calldata actions) external;
 }
 
-// Routers accept "signed" Actions and forwards them to Dispatcher.dispatch
+// Routers accept "signed" bundles of Actions and forwards them to Dispatcher.dispatch
 // They might be a seperate contract or an extension of the Dispatcher
+// A "bundle" here means; one or more actions all signed by the same session key
 interface Router {
-    function dispatch(bytes[][] calldata actions, bytes[] calldata sig) external;
+    function dispatch(bytes[][] calldata actionBundles, bytes[] calldata sig) external;
 
     function authorizeAddr(Dispatcher dispatcher, uint32 ttl, uint32 scopes, address addr) external;
 

--- a/src/SessionRouter.sol
+++ b/src/SessionRouter.sol
@@ -13,7 +13,6 @@ using LibString for uint32;
 bytes constant PREFIX_MESSAGE = "\x19Ethereum Signed Message:\n";
 bytes constant REVOKE_MESSAGE = "You are signing out of session: ";
 
-
 error SessionExpiryTooLong();
 error SessionUnauthorized();
 error SessionExpired();
@@ -35,12 +34,14 @@ contract SessionRouter is Router {
 
     mapping(address => Session) public sessions;
 
-    function getAuthMessage(uint32 ttl, uint32 /*scopes*/, address sessionAddr) internal pure returns (bytes memory) {
+    function getAuthMessage(uint32 ttl, uint32, /*scopes*/ address sessionAddr) internal pure returns (bytes memory) {
         return abi.encodePacked(
             "Welcome!",
             "\n\nThis site is requesting permission to create a temporary session key.",
             "\n\nSigning this message will not incur any fees.",
-            "\n\nValid: ", ttl.toString(), " blocks",
+            "\n\nValid: ",
+            ttl.toString(),
+            " blocks",
             "\n\nSession: ",
             sessionAddr.toHexString()
         );
@@ -52,7 +53,9 @@ contract SessionRouter is Router {
     }
 
     // authorizeKey delegates permissions to key to act as the signer of v/r/s when talking to dispatcher
-    function authorizeAddr(Dispatcher dispatcher, uint32 ttl, uint32 scopes, address sessionAddr, bytes calldata sig) public {
+    function authorizeAddr(Dispatcher dispatcher, uint32 ttl, uint32 scopes, address sessionAddr, bytes calldata sig)
+        public
+    {
         bytes memory authMessage = getAuthMessage(ttl, scopes, sessionAddr);
         address ownerAddr = ecrecover(
             keccak256(abi.encodePacked(PREFIX_MESSAGE, authMessage.length.toString(), authMessage)),

--- a/src/SessionRouter.sol
+++ b/src/SessionRouter.sol
@@ -121,11 +121,7 @@ contract SessionRouter is Router {
             revert SessionExpired();
         }
         // TODO: replay protection
-        Context memory ctx = Context({
-            sender: session.owner,
-            scopes: session.scopes,
-            clock: uint32(block.number)
-        });
+        Context memory ctx = Context({sender: session.owner, scopes: session.scopes, clock: uint32(block.number)});
         // forward to the dispatcher registered with the session
         session.dispatcher.dispatch(actions, ctx);
     }
@@ -147,12 +143,11 @@ contract SessionRouter is Router {
         return uint32(block.number + ttl);
     }
 
-
     // annotations are blobs of data stored in the transaction calldata
     // we take a hash of any annotations and pass the hash to the dispatcher
     // the hash can be used as a reference to data that we can guarentee has been
     // made available to off-chain clients
-    function hashAnnotations(bytes[] calldata annotations) private pure returns(bytes32[] memory) {
+    function hashAnnotations(bytes[] calldata annotations) private pure returns (bytes32[] memory) {
         bytes32[] memory hashes = new bytes32[](annotations.length);
         for (uint256 i = 0; i < annotations.length; i++) {
             hashes[i] = keccak256(annotations[i]);

--- a/src/SessionRouter.sol
+++ b/src/SessionRouter.sol
@@ -95,7 +95,7 @@ contract SessionRouter is Router {
     // | [!] CRITICAL TODO: there is currently no replay protection for session signed actions! |
     // +-----------------------------------------------------------------------------------------+
     //
-    function _dispatch(bytes[] calldata actions, bytes[] calldata annotations, bytes calldata sig) private {
+    function _dispatch(bytes[] calldata actions, bytes calldata sig) private {
         Session storage session;
         if (sig.length == 0) {
             // no signature provided, so we treat the sender as the session key
@@ -124,17 +124,16 @@ contract SessionRouter is Router {
         Context memory ctx = Context({
             sender: session.owner,
             scopes: session.scopes,
-            clock: uint32(block.number),
-            annotations: hashAnnotations(annotations)
+            clock: uint32(block.number)
         });
         // forward to the dispatcher registered with the session
         session.dispatcher.dispatch(actions, ctx);
     }
 
     // dispatch (batched)
-    function dispatch(bytes[][] calldata actions, bytes[][] calldata annotations, bytes[] calldata sig) public {
+    function dispatch(bytes[][] calldata actions, bytes[] calldata sig) public {
         for (uint256 i = 0; i < actions.length; i++) {
-            _dispatch(actions[i], annotations[i], sig[i]);
+            _dispatch(actions[i], sig[i]);
         }
     }
 

--- a/src/State.sol
+++ b/src/State.sol
@@ -28,6 +28,10 @@ enum CompoundKeyKind {
     STRING // key is an 20 byte string
 }
 
+enum AnnotationKind {
+    CALLDATA
+}
+
 library CompoundKeyEncoder {
     function UINT64(bytes4 kindID, uint64 key) internal pure returns (bytes24) {
         return bytes24(abi.encodePacked(kindID, uint96(0), key));
@@ -138,7 +142,7 @@ interface State {
     event NodeTypeRegister(bytes4 id, string name, CompoundKeyKind keyKind);
     event EdgeSet(bytes4 relID, uint8 relKey, bytes24 srcNodeID, bytes24 dstNodeID, uint160 weight);
     event EdgeRemove(bytes4 relID, uint8 relKey, bytes24 srcNodeID);
-    event AnnotationSet(bytes24 id, string label, bytes32 ref);
+    event AnnotationSet(bytes24 id, AnnotationKind kind, string label, bytes32 ref);
 
     function set(bytes4 relID, uint8 relKey, bytes24 srcNodeID, bytes24 dstNodeID, uint64 weight) external;
     function remove(bytes4 relID, uint8 relKey, bytes24 srcNodeID) external;

--- a/src/State.sol
+++ b/src/State.sol
@@ -28,9 +28,7 @@ enum CompoundKeyKind {
     STRING // key is an 20 byte string
 }
 
-enum AnnotationKind {
-    CALLDATA
-}
+enum AnnotationKind {CALLDATA}
 
 library CompoundKeyEncoder {
     function UINT64(bytes4 kindID, uint64 key) internal pure returns (bytes24) {

--- a/src/State.sol
+++ b/src/State.sol
@@ -158,6 +158,5 @@ interface State {
     // not available on-chain, only a content addressable reference to it.
     // indexers/clients are expected to watch for AnnotationSet event and store
     // the annotationData for later lookup
-    function setAnnotation(bytes24 nodeID, string memory label, string memory annotationData) external;
-    function getAnnotationRef(bytes24 nodeID, string memory label) external returns (bytes32 annotationRef);
+    function annotate(bytes24 nodeID, string memory label, string memory annotationData) external;
 }

--- a/src/State.sol
+++ b/src/State.sol
@@ -138,7 +138,7 @@ interface State {
     event NodeTypeRegister(bytes4 id, string name, CompoundKeyKind keyKind);
     event EdgeSet(bytes4 relID, uint8 relKey, bytes24 srcNodeID, bytes24 dstNodeID, uint160 weight);
     event EdgeRemove(bytes4 relID, uint8 relKey, bytes24 srcNodeID);
-    event AnnotationSet(bytes24 nodeID, string annotationLabel, bytes32 annotationDataKey);
+    event AnnotationSet(bytes24 id, string label, bytes32 ref);
 
     function set(bytes4 relID, uint8 relKey, bytes24 srcNodeID, bytes24 dstNodeID, uint64 weight) external;
     function remove(bytes4 relID, uint8 relKey, bytes24 srcNodeID) external;
@@ -151,10 +151,11 @@ interface State {
     function registerEdgeType(bytes4 relID, string memory relName, WeightKind weightKind) external;
     function authorizeContract(address addr) external;
 
-    // an annotation is an on-chain tag that points to some off-chain data
-    // the annotationDataKey is hash, the preimage of the hash can be found
-    // in the transaction calldata. this allows for cost effcient storage of
-    // data blobs that are required by clients but not on-chain
-    function setAnnotation(bytes24 nodeID, string memory annotationLabel, bytes32 annotationDataKey) external;
-    function getAnnotation(bytes24 nodeID, string memory annotationLabel) external returns (bytes32 annotationDataKey);
+    // an annotation is an on-chain tag that points to a (potentially large)
+    // string stored in transaction calldata. The content of annotations are
+    // not available on-chain, only a content addressable reference to it.
+    // indexers/clients are expected to watch for AnnotationSet event and store
+    // the annotationData for later lookup
+    function setAnnotation(bytes24 nodeID, string memory label, string memory annotationData) external;
+    function getAnnotationRef(bytes24 nodeID, string memory label) external returns (bytes32 annotationRef);
 }

--- a/src/State.sol
+++ b/src/State.sol
@@ -138,6 +138,7 @@ interface State {
     event NodeTypeRegister(bytes4 id, string name, CompoundKeyKind keyKind);
     event EdgeSet(bytes4 relID, uint8 relKey, bytes24 srcNodeID, bytes24 dstNodeID, uint160 weight);
     event EdgeRemove(bytes4 relID, uint8 relKey, bytes24 srcNodeID);
+    event AnnotationSet(bytes24 nodeID, string annotationLabel, bytes32 annotationDataKey);
 
     function set(bytes4 relID, uint8 relKey, bytes24 srcNodeID, bytes24 dstNodeID, uint64 weight) external;
     function remove(bytes4 relID, uint8 relKey, bytes24 srcNodeID) external;
@@ -149,4 +150,11 @@ interface State {
     function registerNodeType(bytes4 kindID, string memory kindName, CompoundKeyKind keyKind) external;
     function registerEdgeType(bytes4 relID, string memory relName, WeightKind weightKind) external;
     function authorizeContract(address addr) external;
+
+    // an annotation is an on-chain tag that points to some off-chain data
+    // the annotationDataKey is hash, the preimage of the hash can be found
+    // in the transaction calldata. this allows for cost effcient storage of
+    // data blobs that are required by clients but not on-chain
+    function setAnnotation(bytes24 nodeID, string memory annotationLabel, bytes32 annotationDataKey) external;
+    function getAnnotation(bytes24 nodeID, string memory annotationLabel) external returns (bytes32 annotationDataKey);
 }

--- a/src/State.sol
+++ b/src/State.sol
@@ -142,7 +142,7 @@ interface State {
     event NodeTypeRegister(bytes4 id, string name, CompoundKeyKind keyKind);
     event EdgeSet(bytes4 relID, uint8 relKey, bytes24 srcNodeID, bytes24 dstNodeID, uint160 weight);
     event EdgeRemove(bytes4 relID, uint8 relKey, bytes24 srcNodeID);
-    event AnnotationSet(bytes24 id, AnnotationKind kind, string label, bytes32 ref);
+    event AnnotationSet(bytes24 id, AnnotationKind kind, string label, bytes32 ref, string data);
 
     function set(bytes4 relID, uint8 relKey, bytes24 srcNodeID, bytes24 dstNodeID, uint64 weight) external;
     function remove(bytes4 relID, uint8 relKey, bytes24 srcNodeID) external;

--- a/src/StateGraph.sol
+++ b/src/StateGraph.sol
@@ -47,13 +47,10 @@ contract StateGraph is State {
         return (e.dstNodeID, e.weight);
     }
 
-    function setAnnotationRef(bytes24 nodeID, string memory label, bytes32 annotationRef) private {
-        annotations[nodeID][keccak256(bytes(label))] = annotationRef;
-        emit State.AnnotationSet(nodeID, AnnotationKind.CALLDATA, label, annotationRef);
-    }
-
     function setAnnotation(bytes24 nodeID, string memory label, string memory annotationData) external {
-        setAnnotationRef(nodeID, label, keccak256(bytes(annotationData)));
+        bytes32 annotationRef = keccak256(bytes(annotationData));
+        annotations[nodeID][keccak256(bytes(label))] = annotationRef;
+        emit State.AnnotationSet(nodeID, AnnotationKind.CALLDATA, label, annotationRef, annotationData);
     }
 
     function getAnnotationRef(bytes24 nodeID, string memory annotationLabel) external view returns (bytes32) {

--- a/src/StateGraph.sol
+++ b/src/StateGraph.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import {State, WeightKind, CompoundKeyKind} from "./State.sol";
+import {State, WeightKind, CompoundKeyKind, AnnotationKind} from "./State.sol";
 
 error StateUnauthorizedSender();
 
@@ -49,7 +49,7 @@ contract StateGraph is State {
 
     function setAnnotationRef(bytes24 nodeID, string memory label, bytes32 annotationRef) private {
         annotations[nodeID][keccak256(bytes(label))] = annotationRef;
-        emit State.AnnotationSet(nodeID, label, annotationRef);
+        emit State.AnnotationSet(nodeID, AnnotationKind.CALLDATA, label, annotationRef);
     }
 
     function setAnnotation(bytes24 nodeID, string memory label, string memory annotationData) external {

--- a/src/StateGraph.sol
+++ b/src/StateGraph.sol
@@ -47,7 +47,7 @@ contract StateGraph is State {
         return (e.dstNodeID, e.weight);
     }
 
-    function setAnnotation(bytes24 nodeID, string memory label, string memory annotationData) external {
+    function annotate(bytes24 nodeID, string memory label, string memory annotationData) external {
         bytes32 annotationRef = keccak256(bytes(annotationData));
         annotations[nodeID][keccak256(bytes(label))] = annotationRef;
         emit State.AnnotationSet(nodeID, AnnotationKind.CALLDATA, label, annotationRef, annotationData);

--- a/src/StateGraph.sol
+++ b/src/StateGraph.sol
@@ -12,6 +12,7 @@ contract StateGraph is State {
     }
 
     mapping(bytes24 => mapping(bytes4 => mapping(uint8 => EdgeData))) edges;
+    mapping(bytes24 => mapping(bytes32 => bytes32)) annotations;
     mapping(address => bool) allowlist;
 
     constructor() {
@@ -44,6 +45,15 @@ contract StateGraph is State {
     {
         EdgeData storage e = edges[srcNodeID][relID][relKey];
         return (e.dstNodeID, e.weight);
+    }
+
+    function setAnnotation(bytes24 nodeID, string memory annotationLabel, bytes32 annotationDataKey) external {
+        annotations[nodeID][keccak256(bytes(annotationLabel))] = annotationDataKey;
+        emit State.AnnotationSet(nodeID, annotationLabel, annotationDataKey);
+    }
+
+    function getAnnotation(bytes24 nodeID, string memory annotationLabel) external view returns (bytes32) {
+        return annotations[nodeID][keccak256(bytes(annotationLabel))];
     }
 
     // TODO: allowlist only

--- a/src/StateGraph.sol
+++ b/src/StateGraph.sol
@@ -47,12 +47,16 @@ contract StateGraph is State {
         return (e.dstNodeID, e.weight);
     }
 
-    function setAnnotation(bytes24 nodeID, string memory annotationLabel, bytes32 annotationDataKey) external {
-        annotations[nodeID][keccak256(bytes(annotationLabel))] = annotationDataKey;
-        emit State.AnnotationSet(nodeID, annotationLabel, annotationDataKey);
+    function setAnnotationRef(bytes24 nodeID, string memory label, bytes32 annotationRef) private {
+        annotations[nodeID][keccak256(bytes(label))] = annotationRef;
+        emit State.AnnotationSet(nodeID, label, annotationRef);
     }
 
-    function getAnnotation(bytes24 nodeID, string memory annotationLabel) external view returns (bytes32) {
+    function setAnnotation(bytes24 nodeID, string memory label, string memory annotationData) external {
+        setAnnotationRef(nodeID, label, keccak256(bytes(annotationData)));
+    }
+
+    function getAnnotationRef(bytes24 nodeID, string memory annotationLabel) external view returns (bytes32) {
         return annotations[nodeID][keccak256(bytes(annotationLabel))];
     }
 

--- a/src/utils/LibString.sol
+++ b/src/utils/LibString.sol
@@ -5,6 +5,9 @@ pragma solidity >=0.8.0;
 /// @author Solmate (https://github.com/transmissions11/solmate/blob/main/src/utils/LibString.sol)
 /// @author Modified from Solady (https://github.com/Vectorized/solady/blob/main/src/utils/LibString.sol)
 library LibString {
+    bytes16 private constant _SYMBOLS = "0123456789abcdef";
+    uint8 private constant _ADDRESS_LENGTH = 20;
+
     function toString(uint256 value) internal pure returns (string memory str) {
         /// @solidity memory-safe-assembly
         assembly {
@@ -52,5 +55,22 @@ library LibString {
             // Store the string's length at the start of memory allocated for our string.
             mstore(str, length)
         }
+    }
+
+    function toHexString(uint256 value, uint256 length) internal pure returns (string memory) {
+        bytes memory buffer = new bytes(2 * length + 2);
+        buffer[0] = "0";
+        buffer[1] = "x";
+        for (uint256 i = 2 * length + 1; i > 1; --i) {
+            buffer[i] = _SYMBOLS[value & 0xf];
+            value >>= 4;
+        }
+        require(value == 0, "Strings: hex length insufficient");
+        return string(buffer);
+    }
+
+    // address to NON-CHECKSUMED 0x prefixed hex string
+    function toHexString(address addr) internal pure returns (string memory) {
+        return toHexString(uint256(uint160(addr)), _ADDRESS_LENGTH);
     }
 }

--- a/test/BaseDispatcher.t.sol
+++ b/test/BaseDispatcher.t.sol
@@ -92,8 +92,7 @@ contract BaseDispatcherTest is Test {
         return Context({
             sender: sender,
             scopes: 0,
-            clock: uint32(block.number),
-            annotations: new bytes32[](0)
+            clock: uint32(block.number)
         });
     }
 }

--- a/test/BaseDispatcher.t.sol
+++ b/test/BaseDispatcher.t.sol
@@ -63,7 +63,7 @@ contract BaseDispatcherTest is Test {
 
         d.registerRouter(Router(router));
 
-        Context memory ctx = Context({sender: sender, scopes: 0, clock: uint32(block.number)});
+        Context memory ctx = newContext(sender);
         bytes memory action = abi.encodeCall(TestActions.SET_SENDER, ());
 
         d.registerRule(new LogSenderRule());
@@ -77,7 +77,7 @@ contract BaseDispatcherTest is Test {
         address router = vm.addr(0x88888);
         address sender = vm.addr(0x11111);
 
-        Context memory ctx = Context({sender: sender, scopes: 0, clock: uint32(block.number)});
+        Context memory ctx = newContext(sender);
         bytes memory action = abi.encodeCall(TestActions.SET_SENDER, ());
 
         d.registerRule(new LogSenderRule());
@@ -86,5 +86,14 @@ contract BaseDispatcherTest is Test {
         d.dispatch(action, ctx);
 
         assertEq(s.getAddress(), address(0));
+    }
+
+    function newContext(address sender) private view returns (Context memory) {
+        return Context({
+            sender: sender,
+            scopes: 0,
+            clock: uint32(block.number),
+            annotations: new bytes32[](0)
+        });
     }
 }

--- a/test/BaseDispatcher.t.sol
+++ b/test/BaseDispatcher.t.sol
@@ -89,10 +89,6 @@ contract BaseDispatcherTest is Test {
     }
 
     function newContext(address sender) private view returns (Context memory) {
-        return Context({
-            sender: sender,
-            scopes: 0,
-            clock: uint32(block.number)
-        });
+        return Context({sender: sender, scopes: 0, clock: uint32(block.number)});
     }
 }

--- a/test/BaseGame.t.sol
+++ b/test/BaseGame.t.sol
@@ -68,15 +68,10 @@ contract BaseGameTest is Test {
         game.getRouter().authorizeAddr(game.getDispatcher(), MAX_TTL, SCOPE_FULL_ACCESS, sessionAddr);
         vm.stopPrank();
 
-        // encode annotations for the bundle
-        uint8 annotationID = 0;
-        bytes[] memory annotations = new bytes[](1);
-        annotations[annotationID] = bytes("the-zero-node");
-
         // encode an action bundle
         bytes[] memory actions = new bytes[](2);
         actions[0] = abi.encodeCall(TestActions.SET_BYTES, ("MAGIC_BYTES"));
-        actions[1] = abi.encodeCall(TestActions.ANNOTATE_NODE, (annotationID));
+        actions[1] = abi.encodeCall(TestActions.ANNOTATE_NODE, ("A_POTENTIALLY_REALLY_LONG_UTF8_STRING"));
 
 
         // sign the action bundle with the sessionKey
@@ -87,21 +82,19 @@ contract BaseGameTest is Test {
 
         // add the action bundle to a routing batch
         bytes[][] memory batchedActions = new bytes[][](1);
-        bytes[][] memory batchedAnnotations = new bytes[][](1);
         bytes[] memory batchedSigs = new bytes[](1);
         batchedActions[0] = actions;
-        batchedAnnotations[0] = annotations;
         batchedSigs[0] = sig;
 
         // dispatch the batch via a relayer
         vm.startPrank(relayAddr);
-        game.getRouter().dispatch(batchedActions, batchedAnnotations, batchedSigs);
+        game.getRouter().dispatch(batchedActions, batchedSigs);
         vm.stopPrank();
 
         // check that the state was modified as a reult of running
         // through the rules
         assertEq(game.getState().getBytes(), "MAGIC_BYTES");
-        assertEq(game.getState().getAnnotation(0x0, "name"), keccak256(bytes("the-zero-node")));
+        assertEq(game.getState().getAnnotationRef(0x0, "name"), keccak256(bytes("A_POTENTIALLY_REALLY_LONG_UTF8_STRING")));
     }
 
     function testMetadata() public {

--- a/test/BaseGame.t.sol
+++ b/test/BaseGame.t.sol
@@ -94,9 +94,7 @@ contract BaseGameTest is Test {
         // check that the state was modified as a reult of running
         // through the rules
         assertEq(game.getState().getBytes(), "MAGIC_BYTES");
-        assertEq(
-            state.getAnnotationRef(0x0, "name"), keccak256(bytes("A_POTENTIALLY_REALLY_LONG_UTF8_STRING"))
-        );
+        assertEq(state.getAnnotationRef(0x0, "name"), keccak256(bytes("A_POTENTIALLY_REALLY_LONG_UTF8_STRING")));
     }
 
     function testMetadata() public {

--- a/test/BaseGame.t.sol
+++ b/test/BaseGame.t.sol
@@ -73,7 +73,6 @@ contract BaseGameTest is Test {
         actions[0] = abi.encodeCall(TestActions.SET_BYTES, ("MAGIC_BYTES"));
         actions[1] = abi.encodeCall(TestActions.ANNOTATE_NODE, ("A_POTENTIALLY_REALLY_LONG_UTF8_STRING"));
 
-
         // sign the action bundle with the sessionKey
         vm.startPrank(sessionAddr);
         (uint8 v, bytes32 r, bytes32 s) = sign(actions, sessionKey);
@@ -94,7 +93,9 @@ contract BaseGameTest is Test {
         // check that the state was modified as a reult of running
         // through the rules
         assertEq(game.getState().getBytes(), "MAGIC_BYTES");
-        assertEq(game.getState().getAnnotationRef(0x0, "name"), keccak256(bytes("A_POTENTIALLY_REALLY_LONG_UTF8_STRING")));
+        assertEq(
+            game.getState().getAnnotationRef(0x0, "name"), keccak256(bytes("A_POTENTIALLY_REALLY_LONG_UTF8_STRING"))
+        );
     }
 
     function testMetadata() public {

--- a/test/BaseGame.t.sol
+++ b/test/BaseGame.t.sol
@@ -34,6 +34,7 @@ contract BaseGameTest is Test {
     event GameDeployed(address dispatcherAddr, address stateAddr, address routerAddr);
 
     Game game;
+    StateGraph state;
 
     uint256 ownerKey = 0xA11CE;
     address ownerAddr = vm.addr(ownerKey);
@@ -45,19 +46,19 @@ contract BaseGameTest is Test {
     address relayAddr = vm.addr(relayKey);
 
     function setUp() public {
-        State s = new StateGraph();
+        state = new StateGraph();
         SessionRouter r = new SessionRouter();
         BaseDispatcher d = new BaseDispatcher();
         d.registerRouter(r);
-        d.registerState(s);
+        d.registerState(state);
         d.registerRule(new LogSenderRule());
         d.registerRule(new SetBytesRule());
         d.registerRule(new AnnotateNode());
 
         vm.expectEmit(true, true, true, true);
-        emit GameDeployed(address(d), address(s), address(r));
+        emit GameDeployed(address(d), address(state), address(r));
 
-        game = new ExampleGame(s, d, r);
+        game = new ExampleGame(state, d, r);
     }
 
     // Ensure that we can setup sessions, dispatch signed actions and
@@ -94,7 +95,7 @@ contract BaseGameTest is Test {
         // through the rules
         assertEq(game.getState().getBytes(), "MAGIC_BYTES");
         assertEq(
-            game.getState().getAnnotationRef(0x0, "name"), keccak256(bytes("A_POTENTIALLY_REALLY_LONG_UTF8_STRING"))
+            state.getAnnotationRef(0x0, "name"), keccak256(bytes("A_POTENTIALLY_REALLY_LONG_UTF8_STRING"))
         );
     }
 

--- a/test/SessionRouter.t.sol
+++ b/test/SessionRouter.t.sol
@@ -5,12 +5,7 @@ import "forge-std/Test.sol";
 import {BaseDispatcher, Dispatcher, DispatchUntrustedSender, Rule, Context} from "../src/Dispatcher.sol";
 import {State} from "../src/State.sol";
 import {StateGraph} from "../src/StateGraph.sol";
-import {
-    SessionRouter,
-    SessionUnauthorized,
-    PREFIX_MESSAGE,
-    REVOKE_MESSAGE
-} from "../src/SessionRouter.sol";
+import {SessionRouter, SessionUnauthorized, PREFIX_MESSAGE, REVOKE_MESSAGE} from "../src/SessionRouter.sol";
 
 import "./fixtures/TestActions.sol";
 import "./fixtures/TestRules.sol";
@@ -90,12 +85,8 @@ contract SessionRouterTest is Test {
         );
 
         // owner signs the message authorizing the session
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(
-            ownerKey,
-            keccak256(
-                abi.encodePacked(PREFIX_MESSAGE, authMessage.length.toString(), authMessage)
-            )
-        );
+        (uint8 v, bytes32 r, bytes32 s) =
+            vm.sign(ownerKey, keccak256(abi.encodePacked(PREFIX_MESSAGE, authMessage.length.toString(), authMessage)));
         bytes memory sig = abi.encodePacked(r, s, v);
 
         // relay submits the auth request on behalf of owner

--- a/test/SessionRouter.t.sol
+++ b/test/SessionRouter.t.sol
@@ -141,20 +141,24 @@ contract SessionRouterTest is Test {
     // the LogSenderRule sets the state to the action's owner so we
     // can confirm what the action got processed as
     function dispatchSigned(uint256 privateKey) internal {
-        bytes memory action = abi.encodeCall(TestActions.SET_SENDER, ());
-        bytes32 digest = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", keccak256(action)));
+        bytes[] memory annotations = new bytes[](0);
+        bytes[] memory actions = new bytes[](1);
+        actions[0] = abi.encodeCall(TestActions.SET_SENDER, ());
+        bytes32 digest = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", keccak256(abi.encode(actions))));
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
         bytes memory sig = abi.encodePacked(r, s, v);
 
         // initialize a batch
-        bytes[] memory actions = new bytes[](1);
-        bytes[] memory sigs = new bytes[](1);
+        bytes[][] memory batchedActions = new bytes[][](1);
+        bytes[][] memory batchedAnnotations = new bytes[][](1);
+        bytes[] memory batchedSigs = new bytes[](1);
 
         // assign action into batch
-        actions[0] = action;
-        sigs[0] = sig;
+        batchedActions[0] = actions;
+        batchedAnnotations[0] = annotations;
+        batchedSigs[0] = sig;
 
         vm.prank(relayAddr);
-        router.dispatch(actions, sigs);
+        router.dispatch(batchedActions, batchedAnnotations, batchedSigs);
     }
 }

--- a/test/SessionRouter.t.sol
+++ b/test/SessionRouter.t.sol
@@ -141,7 +141,6 @@ contract SessionRouterTest is Test {
     // the LogSenderRule sets the state to the action's owner so we
     // can confirm what the action got processed as
     function dispatchSigned(uint256 privateKey) internal {
-        bytes[] memory annotations = new bytes[](0);
         bytes[] memory actions = new bytes[](1);
         actions[0] = abi.encodeCall(TestActions.SET_SENDER, ());
         bytes32 digest = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", keccak256(abi.encode(actions))));
@@ -150,15 +149,13 @@ contract SessionRouterTest is Test {
 
         // initialize a batch
         bytes[][] memory batchedActions = new bytes[][](1);
-        bytes[][] memory batchedAnnotations = new bytes[][](1);
         bytes[] memory batchedSigs = new bytes[](1);
 
         // assign action into batch
         batchedActions[0] = actions;
-        batchedAnnotations[0] = annotations;
         batchedSigs[0] = sig;
 
         vm.prank(relayAddr);
-        router.dispatch(batchedActions, batchedAnnotations, batchedSigs);
+        router.dispatch(batchedActions, batchedSigs);
     }
 }

--- a/test/StateGraph.t.sol
+++ b/test/StateGraph.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
-import {State, WeightKind, CompoundKeyKind} from "../src/State.sol";
+import {State, WeightKind, CompoundKeyKind, AnnotationKind} from "../src/State.sol";
 import {StateGraph} from "../src/StateGraph.sol";
 
 interface Rel {
@@ -18,6 +18,7 @@ contract StateGraphTest is Test {
     event NodeTypeRegister(bytes4 id, string name, CompoundKeyKind keyKind);
     event EdgeSet(bytes4 relID, uint8 relKey, bytes24 srcNodeID, bytes24 dstNodeID, uint160 weight);
     event EdgeRemove(bytes4 relID, uint8 relKey, bytes24 srcNodeID);
+    event AnnotationSet(bytes24 id, AnnotationKind kind, string label, bytes32 ref);
 
     StateGraph internal state;
 
@@ -83,5 +84,14 @@ contract StateGraphTest is Test {
         vm.expectEmit(true, true, true, true, address(state));
         emit NodeTypeRegister(relID, relName, keyKind);
         state.registerNodeType(relID, relName, keyKind);
+    }
+
+    function testAnnotateNode() public {
+        bytes24 nodeID = bytes24(abi.encodePacked(Kind.Person.selector, uint64(1)));
+        string memory label = "ann";
+        string memory data = "A_STRING_LONGER_THAN_32_BYTES_1234567890123456789012345678901234567890";
+        vm.expectEmit(true, true, true, true, address(state));
+        emit AnnotationSet(nodeID, AnnotationKind.CALLDATA, label, keccak256(bytes(data)));
+        state.setAnnotation(nodeID, label, data);
     }
 }

--- a/test/StateGraph.t.sol
+++ b/test/StateGraph.t.sol
@@ -92,6 +92,6 @@ contract StateGraphTest is Test {
         string memory data = "A_STRING_LONGER_THAN_32_BYTES_1234567890123456789012345678901234567890";
         vm.expectEmit(true, true, true, true, address(state));
         emit AnnotationSet(nodeID, AnnotationKind.CALLDATA, label, keccak256(bytes(data)), data);
-        state.setAnnotation(nodeID, label, data);
+        state.annotate(nodeID, label, data);
     }
 }

--- a/test/StateGraph.t.sol
+++ b/test/StateGraph.t.sol
@@ -18,7 +18,7 @@ contract StateGraphTest is Test {
     event NodeTypeRegister(bytes4 id, string name, CompoundKeyKind keyKind);
     event EdgeSet(bytes4 relID, uint8 relKey, bytes24 srcNodeID, bytes24 dstNodeID, uint160 weight);
     event EdgeRemove(bytes4 relID, uint8 relKey, bytes24 srcNodeID);
-    event AnnotationSet(bytes24 id, AnnotationKind kind, string label, bytes32 ref);
+    event AnnotationSet(bytes24 id, AnnotationKind kind, string label, bytes32 ref, string data);
 
     StateGraph internal state;
 
@@ -91,7 +91,7 @@ contract StateGraphTest is Test {
         string memory label = "ann";
         string memory data = "A_STRING_LONGER_THAN_32_BYTES_1234567890123456789012345678901234567890";
         vm.expectEmit(true, true, true, true, address(state));
-        emit AnnotationSet(nodeID, AnnotationKind.CALLDATA, label, keccak256(bytes(data)));
+        emit AnnotationSet(nodeID, AnnotationKind.CALLDATA, label, keccak256(bytes(data)), data);
         state.setAnnotation(nodeID, label, data);
     }
 }

--- a/test/fixtures/TestActions.sol
+++ b/test/fixtures/TestActions.sol
@@ -5,5 +5,5 @@ interface TestActions {
     function NOOP() external;
     function SET_SENDER() external;
     function SET_BYTES(bytes memory) external;
-    function ANNOTATE_NODE(uint8 annotationID) external;
+    function ANNOTATE_NODE(string calldata annotationData) external;
 }

--- a/test/fixtures/TestActions.sol
+++ b/test/fixtures/TestActions.sol
@@ -5,4 +5,5 @@ interface TestActions {
     function NOOP() external;
     function SET_SENDER() external;
     function SET_BYTES(bytes memory) external;
+    function ANNOTATE_NODE(uint8 annotationID) external;
 }

--- a/test/fixtures/TestRules.sol
+++ b/test/fixtures/TestRules.sol
@@ -41,10 +41,10 @@ contract LogSenderRule is Rule {
 }
 
 contract AnnotateNode is Rule {
-    function reduce(State s, bytes calldata action, Context calldata ctx ) public returns (State) {
+    function reduce(State s, bytes calldata action, Context calldata /*ctx*/ ) public returns (State) {
         if (bytes4(action) == TestActions.ANNOTATE_NODE.selector) {
-            (uint8 annotationID) = abi.decode(action[4:], (uint8));
-            s.setAnnotation(0x0, "name", ctx.annotations[annotationID]);
+            (string memory data) = abi.decode(action[4:], (string));
+            s.setAnnotation(0x0, "name", data);
         }
         return s;
     }

--- a/test/fixtures/TestRules.sol
+++ b/test/fixtures/TestRules.sol
@@ -44,7 +44,7 @@ contract AnnotateNode is Rule {
     function reduce(State s, bytes calldata action, Context calldata /*ctx*/ ) public returns (State) {
         if (bytes4(action) == TestActions.ANNOTATE_NODE.selector) {
             (string memory data) = abi.decode(action[4:], (string));
-            s.setAnnotation(0x0, "name", data);
+            s.annotate(0x0, "name", data);
         }
         return s;
     }

--- a/test/fixtures/TestRules.sol
+++ b/test/fixtures/TestRules.sol
@@ -39,3 +39,13 @@ contract LogSenderRule is Rule {
         return s;
     }
 }
+
+contract AnnotateNode is Rule {
+    function reduce(State s, bytes calldata action, Context calldata ctx ) public returns (State) {
+        if (bytes4(action) == TestActions.ANNOTATE_NODE.selector) {
+            (uint8 annotationID) = abi.decode(action[4:], (uint8));
+            s.setAnnotation(0x0, "name", ctx.annotations[annotationID]);
+        }
+        return s;
+    }
+}


### PR DESCRIPTION
## What

Adds ability to "annotate" nodes with large UTF8 encoded data.

```
state.setAnnotation(playerID, "bio", "some really long string of data way more than 32bytes as big as you like");
```

An annotation is a key,value label attached to a specific Node where the value of the data written **cannot be read back on-chain, only read back from a client.**

## Why

We have use cases for making data available to clients that is not necasarily useful on-chain.

Examples:

* Blobs of static JSON metadata
* names, summaries, articles, notes that can enrich client experience, but have no need to be queried on-chain
* commitments to data that are later used in off-chain proofs but that we need guarentees were published
