### PR TITLE
support subscribing to Edge/Annotation events

### DIFF
--- a/.github/workflows/check-services-lint.yaml
+++ b/.github/workflows/check-services-lint.yaml
@@ -25,7 +25,7 @@ jobs:
           working-directory: services
 
           # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
+          args: --disable gosimple
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/contracts/src/SessionRouter.sol
+++ b/contracts/src/SessionRouter.sol
@@ -34,7 +34,12 @@ contract SessionRouter is Router {
 
     mapping(address => Session) public sessions;
 
-    function getAuthMessage(uint32 ttl, uint32, /*scopes*/ address sessionAddr) internal virtual pure returns (bytes memory) {
+    function getAuthMessage(uint32 ttl, uint32, /*scopes*/ address sessionAddr)
+        internal
+        pure
+        virtual
+        returns (bytes memory)
+    {
         return abi.encodePacked(
             "Welcome!",
             "\n\nThis site is requesting permission to create a temporary session key.",

--- a/services/pkg/api/model/models_gen.go
+++ b/services/pkg/api/model/models_gen.go
@@ -8,6 +8,10 @@ import (
 	"strconv"
 )
 
+type Event interface {
+	IsEvent()
+}
+
 type Account struct {
 	ID string `json:"id"`
 }
@@ -21,6 +25,7 @@ type Account struct {
 // usually cost-effective for an equivilent value stored in state.
 type Annotation struct {
 	ID    string `json:"id"`
+	Ref   string `json:"ref"`
 	Name  string `json:"name"`
 	Value string `json:"value"`
 }
@@ -72,6 +77,9 @@ type Match struct {
 	Has []*RelMatch `json:"has"`
 	// `limit` stops matches after that many edges have been collected
 	Limit *int `json:"limit"`
+	// how many connections of connections allow to follow when searching
+	// for a match. default=0 (meaning only direct connections)
+	MaxDepth *int `json:"maxDepth"`
 }
 
 // RelMatch configures the types of edges that can be matched.
@@ -83,7 +91,17 @@ type Match struct {
 type RelMatch struct {
 	Rel string             `json:"rel"`
 	Dir *RelMatchDirection `json:"dir"`
+	Key *int               `json:"key"`
 }
+
+type RemoveEdgeEvent struct {
+	ID   string `json:"id"`
+	From string `json:"from"`
+	Rel  string `json:"rel"`
+	Key  int    `json:"key"`
+}
+
+func (RemoveEdgeEvent) IsEvent() {}
 
 type Router struct {
 	ID           string               `json:"id"`
@@ -96,6 +114,24 @@ type Router struct {
 type SessionScope struct {
 	FullAccess bool `json:"FullAccess"`
 }
+
+type SetAnnotationEvent struct {
+	ID   string `json:"id"`
+	From string `json:"from"`
+	Name string `json:"name"`
+}
+
+func (SetAnnotationEvent) IsEvent() {}
+
+type SetEdgeEvent struct {
+	ID   string `json:"id"`
+	From string `json:"from"`
+	To   string `json:"to"`
+	Rel  string `json:"rel"`
+	Key  int    `json:"key"`
+}
+
+func (SetEdgeEvent) IsEvent() {}
 
 type State struct {
 	ID    string `json:"id"`

--- a/services/pkg/api/resolver/subscriptions.resolvers.go
+++ b/services/pkg/api/resolver/subscriptions.resolvers.go
@@ -11,12 +11,12 @@ import (
 	"github.com/playmint/ds-node/pkg/api/model"
 )
 
-func (r *subscriptionResolver) State(ctx context.Context, gameID string) (<-chan *model.State, error) {
+func (r *subscriptionResolver) Events(ctx context.Context, gameID string) (<-chan model.Event, error) {
 	game := r.Indexer.GetGame(gameID)
 	if game == nil {
 		return nil, fmt.Errorf("no game found with id %v", gameID)
 	}
-	return r.Subscriptions.SubscribeState(ctx, game.StateAddress.Hex()), nil
+	return r.Subscriptions.SubscribeStateEvent(ctx, game.StateAddress.Hex()), nil
 }
 
 func (r *subscriptionResolver) Transaction(ctx context.Context, gameID string, owner *string) (<-chan *model.ActionTransaction, error) {

--- a/services/schema/state.graphqls
+++ b/services/schema/state.graphqls
@@ -35,6 +35,12 @@ input Match {
 	`limit` stops matches after that many edges have been collected
 	"""
 	limit: Int
+
+	"""
+	how many connections of connections allow to follow when searching
+	for a match. default=0 (meaning only direct connections)
+	"""
+	maxDepth: Int
 }
 
 """
@@ -61,6 +67,7 @@ outbound or inbound direction from this node.
 input RelMatch {
 	rel: String!
 	dir: RelMatchDirection
+	key: Int
 }
 
 type State {
@@ -168,9 +175,32 @@ with the edge that we followed.
 """
 type Edge {
   """
+  edge ids are "virtual" ids that only exist so you can fetch a particular edge
+  in isolation. they are a compound key of DIR+REL+KEY+NODE.ID+PARENT.ID this
+  means that for every "real" edge there are two "virtual" edges with different
+  graphql IDs (one pointing one way, one pointing the other).  this allows for
+  invalidating caches and fetching partial results for edge queries.
+  """
+  id: ID!
+
+  """
   the node on the `dir` end of this edge.
   """
   node: Node!
+
+  """
+  the true source end of the edge (unlike `node` which is based on current Dir)
+  you probably want `node` not this, but sometimes it's useful when dealing
+  with lists of edges
+  """
+  src: Node!
+
+  """
+  the true dest end of the edge (unlike `node` which is based on the current
+  Dir) you probably want `node` not this, but sometimes it's useful when
+  dealing with lists of edges
+  """
+  dst: Node!
 
   """
   `weight` is the value stored in the edge
@@ -247,6 +277,7 @@ usually cost-effective for an equivilent value stored in state.
 """
 type Annotation {
 	id: ID!
+	ref: String!
 	name: String!
 	value: String!
 }

--- a/services/schema/subscriptions.graphqls
+++ b/services/schema/subscriptions.graphqls
@@ -1,7 +1,32 @@
 
+interface Event {
+	id: ID!
+}
+
+type SetEdgeEvent implements Event {
+	id: ID!
+	from: String!
+	to: String!
+	rel: String!
+	key: Int!
+}
+
+type RemoveEdgeEvent implements Event {
+	id: ID!
+	from: String!
+	rel: String!
+	key: Int!
+}
+
+type SetAnnotationEvent implements Event {
+	id: ID!
+	from: String!
+	name: String!
+}
+
 
 type Subscription {
-	state(gameID: ID!): State
+	events(gameID: ID!): Event!
 	transaction(gameID: ID!, owner: String): ActionTransaction!
 	session(gameID: ID!, owner: String): Session!
 }


### PR DESCRIPTION
subscribing to large State queries is bad for performance. I removed this feature as it was a footgun.

instead we should subscribe to the edge/annotation changes and then let the client work out what it needs to re-query.

bonus; fixes the matcher bug that dropped edges in match results by rewriting the match logic in a more naive way ... when it's time for persistance we will not want to be using any of this logic anyway and hopefully use some more full featured lib/db