### PR TITLE
faster commit time

### DIFF
--- a/services/pkg/config/config.go
+++ b/services/pkg/config/config.go
@@ -10,6 +10,6 @@ var SequencerProviderHTTP = getRequiredEnvString("SEQUENCER_PROVIDER_URL_HTTP")
 var SequencerProviderWS = getRequiredEnvString("SEQUENCER_PROVIDER_URL_WS")
 var SequencerPrivateKey = getRequiredEnvKey("SEQUENCER_PRIVATE_KEY")
 var SequencerMaxConcurrency = getOptionalEnvInt("SEQUENCER_MAX_CONCURRENCY", 200)
-var SequencerMinBatchDelaySeconds = getOptionalEnvInt("SEQUENCER_MIN_BATCH_DELAY_SECONDS", 1)
+var SequencerMinBatchDelayMilliseconds = getOptionalEnvInt("SEQUENCER_MIN_BATCH_DELAY_MS", 100)
 
 var APIPort = getOptionalEnvInt("API_PORT", 8080)

--- a/services/pkg/sequencer/sequencer.go
+++ b/services/pkg/sequencer/sequencer.go
@@ -90,14 +90,14 @@ func NewMemorySequencer(ctx context.Context, key *ecdsa.PrivateKey, notification
 	seqr.failure = map[string][]*model.ActionBatch{}
 
 	// drain the queue every few seconds
-	timer := time.NewTimer(time.Duration(config.SequencerMinBatchDelaySeconds) * time.Second)
+	timer := time.NewTimer(time.Duration(config.SequencerMinBatchDelayMilliseconds) * time.Millisecond)
 	shutdown := ctx.Done()
 	go func() {
 		for {
 			select {
 			case <-timer.C:
 				seqr.commit(ctx)
-				timer.Reset(time.Duration(config.SequencerMinBatchDelaySeconds) * time.Second)
+				timer.Reset(time.Duration(config.SequencerMinBatchDelayMilliseconds) * time.Millisecond)
 			case <-shutdown:
 				timer.Stop()
 				return


### PR DESCRIPTION
we don't need to wait as long before commits. the important thing is that we are queuing up tx while processing one, so the delay is just artifically slowing things down.

100ms chosen a sensible idle cpu clamp more than anything else