### PR TITLE
expose number of active subscribers

### DIFF
--- a/services/pkg/api/resolver/game.resolvers.go
+++ b/services/pkg/api/resolver/game.resolvers.go
@@ -18,6 +18,17 @@ func (r *gameResolver) State(ctx context.Context, obj *model.Game, block *int, s
 	return obj.State(block, simulated), nil
 }
 
+func (r *gameResolver) Subscribers(ctx context.Context, obj *model.Game) (int, error) {
+	if r.Subscriptions == nil && r.Subscriptions.Events == nil {
+		return 0, nil
+	}
+	subs, ok := r.Subscriptions.Events[obj.StateAddress.Hex()]
+	if !ok {
+		return 0, nil
+	}
+	return len(subs), nil
+}
+
 // Game returns generated.GameResolver implementation.
 func (r *Resolver) Game() generated.GameResolver { return &gameResolver{r} }
 

--- a/services/schema/game.graphqls
+++ b/services/schema/game.graphqls
@@ -10,4 +10,5 @@ type Game {
 	dispatcher: Dispatcher!
 	state(block: Int, simulated: Boolean): State!
 	router: Router!
+	subscribers: Int!
 }


### PR DESCRIPTION
quick n dirty way to see number of socket connections to a game state from a graphql query

```
{
  games {
    name    
    subscribers
  }
}
```
