### PR TITLE
prevent panic on get-batch failure

### DIFF
--- a/services/pkg/indexer/indexer.go
+++ b/services/pkg/indexer/indexer.go
@@ -70,7 +70,6 @@ func NewMemoryIndexer(ctx context.Context, notifications chan interface{}, httpP
 	idxr.events, err = eventwatcher.New(eventwatcher.Config{
 		HTTPClient:    idxr.httpClient,
 		Websocket:     idxr.wsClient,
-		Concurrency:   1, // config.IndexerMaxConcurrency, - NodeSet/EdgeSet cannot arrive out of order yet
 		LogRange:      config.IndexerMaxLogRange,
 		Notifications: notifications,
 	})
@@ -122,7 +121,6 @@ func (idxr *MemoryIndexer) NewSim(ctx context.Context, blockNumber uint64, httpS
 	events, err := eventwatcher.New(eventwatcher.Config{
 		HTTPClient:    httpSimClient,
 		Websocket:     wsSimClient,
-		Concurrency:   1,
 		LogRange:      config.IndexerMaxLogRange,
 		EpochBlock:    int64(blockNumber),
 		Simulated:     true,


### PR DESCRIPTION
simplify the retry loop to ensure that we do not skip events and do not crash on context cancels.

this could result in retries forever if the chain crashes, but everything is broken anyway in that case so retrying in the pathalogical case is more desirable than crashing in the maybe-recoverable case

fixes: #23 