### PR TITLE
avoid fork-wait deadlock during cold start

### DIFF
--- a/services/cmd/ds-node/server.go
+++ b/services/cmd/ds-node/server.go
@@ -52,6 +52,7 @@ func Main(ctx context.Context) error {
 		config.SequencerProviderHTTP,
 		config.SimulationProviderHTTP,
 		config.SimulationProviderWS,
+		config.SequencerMineEmpty,
 		idxr,
 	)
 	if err != nil {

--- a/services/pkg/config/config.go
+++ b/services/pkg/config/config.go
@@ -11,6 +11,7 @@ var SequencerProviderWS = getRequiredEnvString("SEQUENCER_PROVIDER_URL_WS")
 var SequencerPrivateKey = getRequiredEnvKey("SEQUENCER_PRIVATE_KEY")
 var SequencerMaxConcurrency = getOptionalEnvInt("SEQUENCER_MAX_CONCURRENCY", 200)
 var SequencerMinBatchDelayMilliseconds = getOptionalEnvInt("SEQUENCER_MIN_BATCH_DELAY_MS", 100)
+var SequencerMineEmpty = getOptionalEnvBool("SEQUENCER_MINE_EMPTY", "true")
 
 var SimulationProviderHTTP = getRequiredEnvString("SIMULATION_PROVIDER_URL_HTTP")
 var SimulationProviderWS = getRequiredEnvString("SIMULATION_PROVIDER_URL_WS")

--- a/services/pkg/sequencer/sequencer.go
+++ b/services/pkg/sequencer/sequencer.go
@@ -359,8 +359,8 @@ func (seqr *MemorySequencer) commitTxWithClient(
 	}
 
 	txOpts.Context = ctx
-	txOpts.Value = big.NewInt(0)         // in wei
-	txOpts.GasLimit = uint64(3000000000) // in units
+	txOpts.Value = big.NewInt(0)      // in wei
+	txOpts.GasLimit = uint64(3000000) // in units
 
 	tx, err := sessionRouter.Dispatch(txOpts,
 		actions,


### PR DESCRIPTION
during a cold start, when the indexer is not yet caught up to the current block, a sim fork at block B must wait for the indexer to catch up to block B

during cold start blocks are not read one-by-one, but in large range chunks

the check to release the indexer fork-wait lock did not account for the range, and was only checking the exact latest block number in the range, causing it to deadlock if the block was in the middle of the range