### PR TITLE
allow restricting indexer to single game addr

### DIFF
--- a/services/pkg/config/config.go
+++ b/services/pkg/config/config.go
@@ -1,10 +1,13 @@
 package config
 
+import "github.com/ethereum/go-ethereum/common"
+
 var IndexerProviderHTTP = getRequiredEnvString("INDEXER_PROVIDER_URL_HTTP")
 var IndexerProviderWS = getRequiredEnvString("INDEXER_PROVIDER_URL_WS")
 var IndexerMaxConcurrency = getOptionalEnvInt("INDEXER_MAX_CONCURRENCY", 200)
 var IndexerMaxLogRange = getOptionalEnvInt("INDEXER_MAX_LOG_RANGE", 1000)
 var IndexerWatchPending = getOptionalEnvBool("INDEXER_WATCH_PENDING", "true")
+var IndexerGameAddress = getOptionalEnvAddress("INDEXER_GAME_ADDRESS", common.Address{})
 
 var SequencerProviderHTTP = getRequiredEnvString("SEQUENCER_PROVIDER_URL_HTTP")
 var SequencerProviderWS = getRequiredEnvString("SEQUENCER_PROVIDER_URL_WS")

--- a/services/pkg/config/env.go
+++ b/services/pkg/config/env.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
@@ -15,6 +16,14 @@ func getRequiredEnvString(name string) string {
 		panic(fmt.Sprintf("required environment variable %s missing", name))
 	}
 	return v
+}
+
+func getOptionalEnvAddress(name string, defvalue common.Address) common.Address {
+	v := os.Getenv(name)
+	if v == "" {
+		return defvalue
+	}
+	return common.HexToAddress(v)
 }
 
 func getOptionalEnvInt(name string, defvalue int) int {

--- a/services/pkg/indexer/stores/cog/game_store.go
+++ b/services/pkg/indexer/stores/cog/game_store.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/benbjohnson/immutable"
 	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/playmint/ds-node/pkg/api/model"
 	"github.com/playmint/ds-node/pkg/client/alchemy"
+	"github.com/playmint/ds-node/pkg/config"
 	"github.com/playmint/ds-node/pkg/contracts/game"
 	"github.com/playmint/ds-node/pkg/indexer/eventwatcher"
 	"github.com/rs/zerolog"
@@ -100,6 +102,13 @@ func (rs *GameStore) setGame(evt *game.BaseGameGameDeployed) error {
 	if evt.Raw.Removed {
 		// hmmm blockchain reorg occured so what do we do?
 		// just ignore for now, but this probably needs more thought
+		return nil
+	}
+
+	// if we are configured to only index a single game id
+	// then ignore any others
+	if config.IndexerGameAddress != common.HexToAddress("") && evt.Raw.Address != config.IndexerGameAddress {
+		rs.log.Warn().Msgf("ignoring game %s as we are configued to index %s only", evt.Raw.Address.Hex(), config.IndexerGameAddress.Hex())
 		return nil
 	}
 


### PR DESCRIPTION
we don't always want to index ALL games we find, sometimes we want to pin the indexer to watch a specific game contract.

this adds INDEXER_GAME_ADDRESS config which when set ignores other game addrs

this has the effect that we can continue to use the "latest" and "downstream" shortcut ids, even when other "downstream" games exist