### PR TITLE
Adding the ability to store data as 32byte key value pairs on a Node

### DIFF
--- a/contracts/src/IState.sol
+++ b/contracts/src/IState.sol
@@ -26,9 +26,12 @@ enum CompoundKeyKind {
     ADDRESS, // key is 20 byte address
     BYTES, // key is an 20 byte blob of data
     STRING // key is an 20 byte string
+
 }
 
-enum AnnotationKind {CALLDATA}
+enum AnnotationKind {
+    CALLDATA
+}
 
 library CompoundKeyEncoder {
     function UINT64(bytes4 kindID, uint64 key) internal pure returns (bytes24) {

--- a/contracts/src/IState.sol
+++ b/contracts/src/IState.sol
@@ -141,6 +141,7 @@ interface State {
     event EdgeSet(bytes4 relID, uint8 relKey, bytes24 srcNodeID, bytes24 dstNodeID, uint160 weight);
     event EdgeRemove(bytes4 relID, uint8 relKey, bytes24 srcNodeID);
     event AnnotationSet(bytes24 id, AnnotationKind kind, string label, bytes32 ref, string data);
+    event DataSet(bytes24 id, string label, bytes32 data);
 
     // FIXME: lazy, this is totally the wrong place for this, but it makes indexing easier
     event SeenOpSet(bytes sig);
@@ -162,4 +163,7 @@ interface State {
     // indexers/clients are expected to watch for AnnotationSet event and store
     // the annotationData for later lookup
     function annotate(bytes24 nodeID, string memory label, string memory annotationData) external;
+
+    function setData(bytes24 nodeID, string memory label, bytes32 data) external;
+    function getData(bytes24 nodeID, string memory annotationLabel) external view returns (bytes32);
 }

--- a/services/pkg/api/generated/generated.go
+++ b/services/pkg/api/generated/generated.go
@@ -145,9 +145,11 @@ type ComplexityRoot struct {
 	}
 
 	Node struct {
+		AllData     func(childComplexity int) int
 		Annotation  func(childComplexity int, name string) int
 		Annotations func(childComplexity int) int
 		Count       func(childComplexity int, match *model.Match) int
+		Data        func(childComplexity int, name string) int
 		Edge        func(childComplexity int, match *model.Match) int
 		Edges       func(childComplexity int, match *model.Match) int
 		ID          func(childComplexity int) int
@@ -158,6 +160,12 @@ type ComplexityRoot struct {
 		Nodes       func(childComplexity int, match *model.Match) int
 		Sum         func(childComplexity int, match *model.Match) int
 		Value       func(childComplexity int, match *model.Match) int
+	}
+
+	NodeData struct {
+		ID    func(childComplexity int) int
+		Name  func(childComplexity int) int
+		Value func(childComplexity int) int
 	}
 
 	Query struct {
@@ -674,6 +682,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.Signup(childComplexity, args["gameID"].(string), args["authorization"].(string)), true
 
+	case "Node.allData":
+		if e.complexity.Node.AllData == nil {
+			break
+		}
+
+		return e.complexity.Node.AllData(childComplexity), true
+
 	case "Node.annotation":
 		if e.complexity.Node.Annotation == nil {
 			break
@@ -704,6 +719,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Node.Count(childComplexity, args["match"].(*model.Match)), true
+
+	case "Node.data":
+		if e.complexity.Node.Data == nil {
+			break
+		}
+
+		args, err := ec.field_Node_data_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Node.Data(childComplexity, args["name"].(string)), true
 
 	case "Node.edge":
 		if e.complexity.Node.Edge == nil {
@@ -804,6 +831,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Node.Value(childComplexity, args["match"].(*model.Match)), true
+
+	case "NodeData.id":
+		if e.complexity.NodeData.ID == nil {
+			break
+		}
+
+		return e.complexity.NodeData.ID(childComplexity), true
+
+	case "NodeData.name":
+		if e.complexity.NodeData.Name == nil {
+			break
+		}
+
+		return e.complexity.NodeData.Name(childComplexity), true
+
+	case "NodeData.value":
+		if e.complexity.NodeData.Value == nil {
+			break
+		}
+
+		return e.complexity.NodeData.Value(childComplexity), true
 
 	case "Query.game":
 		if e.complexity.Query.Game == nil {
@@ -1336,6 +1384,12 @@ type Node {
 	annotation(name: String!): Annotation
 
 	"""
+	allData is the store of on-chain 32byte key value pairs belonging to the node
+	"""
+	allData: [NodeData]!
+	data(name: String!): NodeData
+
+	"""
 	nodes have a "kind" label, it is the human friendly decoding of the first 4
 	bytes of the id. See ` + "`" + `id` + "`" + ` and ` + "`" + `keys` + "`" + `. This value is discovered based on the
 	value set on the state contract via registerNodeType.
@@ -1493,6 +1547,15 @@ usually cost-effective for an equivilent value stored in state.
 type Annotation {
 	id: ID!
 	ref: String!
+	name: String!
+	value: String!
+}
+
+"""
+node data is an on-chain 32byte value stored as a key value pair for a given node
+"""
+type NodeData {
+	id: ID!
 	name: String!
 	value: String!
 }
@@ -1731,6 +1794,21 @@ func (ec *executionContext) field_Node_count_args(ctx context.Context, rawArgs m
 		}
 	}
 	args["match"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Node_data_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["name"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["name"] = arg0
 	return args, nil
 }
 
@@ -4263,6 +4341,80 @@ func (ec *executionContext) _Node_annotation(ctx context.Context, field graphql.
 	return ec.marshalOAnnotation2ᚖgithubᚗcomᚋplaymintᚋdsᚑnodeᚋpkgᚋapiᚋmodelᚐAnnotation(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Node_allData(ctx context.Context, field graphql.CollectedField, obj *model.Node) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Node",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AllData(), nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.NodeData)
+	fc.Result = res
+	return ec.marshalNNodeData2ᚕᚖgithubᚗcomᚋplaymintᚋdsᚑnodeᚋpkgᚋapiᚋmodelᚐNodeData(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Node_data(ctx context.Context, field graphql.CollectedField, obj *model.Node) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Node",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Node_data_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Data(args["name"].(string)), nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.NodeData)
+	fc.Result = res
+	return ec.marshalONodeData2ᚖgithubᚗcomᚋplaymintᚋdsᚑnodeᚋpkgᚋapiᚋmodelᚐNodeData(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Node_kind(ctx context.Context, field graphql.CollectedField, obj *model.Node) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -4581,6 +4733,111 @@ func (ec *executionContext) _Node_count(ctx context.Context, field graphql.Colle
 	res := resTmp.(int)
 	fc.Result = res
 	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _NodeData_id(ctx context.Context, field graphql.CollectedField, obj *model.NodeData) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "NodeData",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _NodeData_name(ctx context.Context, field graphql.CollectedField, obj *model.NodeData) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "NodeData",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _NodeData_value(ctx context.Context, field graphql.CollectedField, obj *model.NodeData) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "NodeData",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Value, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_game(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -7666,6 +7923,23 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 
 			out.Values[i] = innerFunc(ctx)
 
+		case "allData":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Node_allData(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "data":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Node_data(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
 		case "kind":
 			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Node_kind(ctx, field, obj)
@@ -7730,6 +8004,57 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 		case "count":
 			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Node_count(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var nodeDataImplementors = []string{"NodeData"}
+
+func (ec *executionContext) _NodeData(ctx context.Context, sel ast.SelectionSet, obj *model.NodeData) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, nodeDataImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("NodeData")
+		case "id":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._NodeData_id(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "name":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._NodeData_name(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "value":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._NodeData_value(ctx, field, obj)
 			}
 
 			out.Values[i] = innerFunc(ctx)
@@ -9034,6 +9359,44 @@ func (ec *executionContext) marshalNNode2ᚖgithubᚗcomᚋplaymintᚋdsᚑnode�
 	return ec._Node(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNNodeData2ᚕᚖgithubᚗcomᚋplaymintᚋdsᚑnodeᚋpkgᚋapiᚋmodelᚐNodeData(ctx context.Context, sel ast.SelectionSet, v []*model.NodeData) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalONodeData2ᚖgithubᚗcomᚋplaymintᚋdsᚑnodeᚋpkgᚋapiᚋmodelᚐNodeData(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	return ret
+}
+
 func (ec *executionContext) unmarshalNRelMatch2ᚖgithubᚗcomᚋplaymintᚋdsᚑnodeᚋpkgᚋapiᚋmodelᚐRelMatch(ctx context.Context, v interface{}) (*model.RelMatch, error) {
 	res, err := ec.unmarshalInputRelMatch(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
@@ -9600,6 +9963,13 @@ func (ec *executionContext) marshalONode2ᚖgithubᚗcomᚋplaymintᚋdsᚑnode�
 		return graphql.Null
 	}
 	return ec._Node(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalONodeData2ᚖgithubᚗcomᚋplaymintᚋdsᚑnodeᚋpkgᚋapiᚋmodelᚐNodeData(ctx context.Context, sel ast.SelectionSet, v *model.NodeData) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._NodeData(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalORelMatch2ᚕᚖgithubᚗcomᚋplaymintᚋdsᚑnodeᚋpkgᚋapiᚋmodelᚐRelMatchᚄ(ctx context.Context, v interface{}) ([]*model.RelMatch, error) {

--- a/services/pkg/api/model/models_gen.go
+++ b/services/pkg/api/model/models_gen.go
@@ -91,6 +91,13 @@ type Match struct {
 	MaxDepth *int `json:"maxDepth"`
 }
 
+// node data is an on-chain 32byte value stored as a key value pair for a given node
+type NodeData struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
 // RelMatch configures the types of edges that can be matched.
 //
 // rel is the human friendly name of the relationship.

--- a/services/pkg/contracts/router/SessionRouter.go
+++ b/services/pkg/contracts/router/SessionRouter.go
@@ -26,7 +26,6 @@ var (
 	_ = common.Big1
 	_ = types.BloomLookup
 	_ = event.NewSubscription
-	_ = abi.ConvertType
 )
 
 // Op is an auto generated low-level Go binding around an user-defined struct.
@@ -39,11 +38,12 @@ type Op struct {
 	Weight    *big.Int
 	AnnName   string
 	AnnData   string
+	NodeData  [32]byte
 }
 
 // SessionRouterMetaData contains all meta data concerning the SessionRouter contract.
 var SessionRouterMetaData = &bind.MetaData{
-	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"sig\",\"type\":\"bytes\"}],\"name\":\"SeenOpSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"session\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"exp\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"scopes\",\"type\":\"uint32\"}],\"name\":\"SessionCreate\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"session\",\"type\":\"address\"}],\"name\":\"SessionDestroy\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"contractDispatcher\",\"name\":\"dispatcher\",\"type\":\"address\"},{\"internalType\":\"uint32\",\"name\":\"ttl\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"scopes\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"sessionAddr\",\"type\":\"address\"}],\"name\":\"authorizeAddr\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractDispatcher\",\"name\":\"dispatcher\",\"type\":\"address\"},{\"internalType\":\"uint32\",\"name\":\"ttl\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"scopes\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"sessionAddr\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"sig\",\"type\":\"bytes\"}],\"name\":\"authorizeAddr\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes[]\",\"name\":\"actions\",\"type\":\"bytes[]\"},{\"internalType\":\"bytes\",\"name\":\"sig\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"}],\"name\":\"dispatch\",\"outputs\":[{\"components\":[{\"internalType\":\"enumOpKind\",\"name\":\"kind\",\"type\":\"uint8\"},{\"internalType\":\"bytes4\",\"name\":\"relID\",\"type\":\"bytes4\"},{\"internalType\":\"uint8\",\"name\":\"relKey\",\"type\":\"uint8\"},{\"internalType\":\"bytes24\",\"name\":\"srcNodeID\",\"type\":\"bytes24\"},{\"internalType\":\"bytes24\",\"name\":\"dstNodeID\",\"type\":\"bytes24\"},{\"internalType\":\"uint160\",\"name\":\"weight\",\"type\":\"uint160\"},{\"internalType\":\"string\",\"name\":\"annName\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"annData\",\"type\":\"string\"}],\"internalType\":\"structOp[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"sig\",\"type\":\"bytes\"}],\"name\":\"revokeAddr\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"revokeAddr\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"sessions\",\"outputs\":[{\"internalType\":\"contractDispatcher\",\"name\":\"dispatcher\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"uint32\",\"name\":\"exp\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"scopes\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"sig\",\"type\":\"bytes\"}],\"name\":\"SeenOpSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"session\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"exp\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"scopes\",\"type\":\"uint32\"}],\"name\":\"SessionCreate\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"session\",\"type\":\"address\"}],\"name\":\"SessionDestroy\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"contractDispatcher\",\"name\":\"dispatcher\",\"type\":\"address\"},{\"internalType\":\"uint32\",\"name\":\"ttl\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"scopes\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"sessionAddr\",\"type\":\"address\"}],\"name\":\"authorizeAddr\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractDispatcher\",\"name\":\"dispatcher\",\"type\":\"address\"},{\"internalType\":\"uint32\",\"name\":\"ttl\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"scopes\",\"type\":\"uint32\"},{\"internalType\":\"address\",\"name\":\"sessionAddr\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"sig\",\"type\":\"bytes\"}],\"name\":\"authorizeAddr\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes[]\",\"name\":\"actions\",\"type\":\"bytes[]\"},{\"internalType\":\"bytes\",\"name\":\"sig\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"}],\"name\":\"dispatch\",\"outputs\":[{\"components\":[{\"internalType\":\"enumOpKind\",\"name\":\"kind\",\"type\":\"uint8\"},{\"internalType\":\"bytes4\",\"name\":\"relID\",\"type\":\"bytes4\"},{\"internalType\":\"uint8\",\"name\":\"relKey\",\"type\":\"uint8\"},{\"internalType\":\"bytes24\",\"name\":\"srcNodeID\",\"type\":\"bytes24\"},{\"internalType\":\"bytes24\",\"name\":\"dstNodeID\",\"type\":\"bytes24\"},{\"internalType\":\"uint160\",\"name\":\"weight\",\"type\":\"uint160\"},{\"internalType\":\"string\",\"name\":\"annName\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"annData\",\"type\":\"string\"},{\"internalType\":\"bytes32\",\"name\":\"nodeData\",\"type\":\"bytes32\"}],\"internalType\":\"structOp[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"sig\",\"type\":\"bytes\"}],\"name\":\"revokeAddr\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"revokeAddr\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"sessions\",\"outputs\":[{\"internalType\":\"contractDispatcher\",\"name\":\"dispatcher\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"uint32\",\"name\":\"exp\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"scopes\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
 }
 
 // SessionRouterABI is the input ABI used to generate the binding from.
@@ -147,11 +147,11 @@ func NewSessionRouterFilterer(address common.Address, filterer bind.ContractFilt
 
 // bindSessionRouter binds a generic wrapper to an already deployed contract.
 func bindSessionRouter(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
-	parsed, err := SessionRouterMetaData.GetAbi()
+	parsed, err := abi.JSON(strings.NewReader(SessionRouterABI))
 	if err != nil {
 		return nil, err
 	}
-	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
 }
 
 // Call invokes the (constant) contract method with params as input values and
@@ -291,21 +291,21 @@ func (_SessionRouter *SessionRouterTransactorSession) AuthorizeAddr0(dispatcher 
 
 // Dispatch is a paid mutator transaction binding the contract method 0x6fdc0e10.
 //
-// Solidity: function dispatch(bytes[] actions, bytes sig, uint256 nonce) returns((uint8,bytes4,uint8,bytes24,bytes24,uint160,string,string)[])
+// Solidity: function dispatch(bytes[] actions, bytes sig, uint256 nonce) returns((uint8,bytes4,uint8,bytes24,bytes24,uint160,string,string,bytes32)[])
 func (_SessionRouter *SessionRouterTransactor) Dispatch(opts *bind.TransactOpts, actions [][]byte, sig []byte, nonce *big.Int) (*types.Transaction, error) {
 	return _SessionRouter.contract.Transact(opts, "dispatch", actions, sig, nonce)
 }
 
 // Dispatch is a paid mutator transaction binding the contract method 0x6fdc0e10.
 //
-// Solidity: function dispatch(bytes[] actions, bytes sig, uint256 nonce) returns((uint8,bytes4,uint8,bytes24,bytes24,uint160,string,string)[])
+// Solidity: function dispatch(bytes[] actions, bytes sig, uint256 nonce) returns((uint8,bytes4,uint8,bytes24,bytes24,uint160,string,string,bytes32)[])
 func (_SessionRouter *SessionRouterSession) Dispatch(actions [][]byte, sig []byte, nonce *big.Int) (*types.Transaction, error) {
 	return _SessionRouter.Contract.Dispatch(&_SessionRouter.TransactOpts, actions, sig, nonce)
 }
 
 // Dispatch is a paid mutator transaction binding the contract method 0x6fdc0e10.
 //
-// Solidity: function dispatch(bytes[] actions, bytes sig, uint256 nonce) returns((uint8,bytes4,uint8,bytes24,bytes24,uint160,string,string)[])
+// Solidity: function dispatch(bytes[] actions, bytes sig, uint256 nonce) returns((uint8,bytes4,uint8,bytes24,bytes24,uint160,string,string,bytes32)[])
 func (_SessionRouter *SessionRouterTransactorSession) Dispatch(actions [][]byte, sig []byte, nonce *big.Int) (*types.Transaction, error) {
 	return _SessionRouter.Contract.Dispatch(&_SessionRouter.TransactOpts, actions, sig, nonce)
 }

--- a/services/pkg/contracts/state/State.go
+++ b/services/pkg/contracts/state/State.go
@@ -26,12 +26,11 @@ var (
 	_ = common.Big1
 	_ = types.BloomLookup
 	_ = event.NewSubscription
-	_ = abi.ConvertType
 )
 
 // StateMetaData contains all meta data concerning the State contract.
 var StateMetaData = &bind.MetaData{
-	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes24\",\"name\":\"id\",\"type\":\"bytes24\"},{\"indexed\":false,\"internalType\":\"enumAnnotationKind\",\"name\":\"kind\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"label\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"ref\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"data\",\"type\":\"string\"}],\"name\":\"AnnotationSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes4\",\"name\":\"relID\",\"type\":\"bytes4\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"relKey\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"bytes24\",\"name\":\"srcNodeID\",\"type\":\"bytes24\"}],\"name\":\"EdgeRemove\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes4\",\"name\":\"relID\",\"type\":\"bytes4\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"relKey\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"bytes24\",\"name\":\"srcNodeID\",\"type\":\"bytes24\"},{\"indexed\":false,\"internalType\":\"bytes24\",\"name\":\"dstNodeID\",\"type\":\"bytes24\"},{\"indexed\":false,\"internalType\":\"uint160\",\"name\":\"weight\",\"type\":\"uint160\"}],\"name\":\"EdgeSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes4\",\"name\":\"id\",\"type\":\"bytes4\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"enumWeightKind\",\"name\":\"kind\",\"type\":\"uint8\"}],\"name\":\"EdgeTypeRegister\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes4\",\"name\":\"id\",\"type\":\"bytes4\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"enumCompoundKeyKind\",\"name\":\"keyKind\",\"type\":\"uint8\"}],\"name\":\"NodeTypeRegister\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"sig\",\"type\":\"bytes\"}],\"name\":\"SeenOpSet\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"bytes24\",\"name\":\"nodeID\",\"type\":\"bytes24\"},{\"internalType\":\"string\",\"name\":\"label\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"annotationData\",\"type\":\"string\"}],\"name\":\"annotate\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"authorizeContract\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"relID\",\"type\":\"bytes4\"},{\"internalType\":\"uint8\",\"name\":\"relKey\",\"type\":\"uint8\"},{\"internalType\":\"bytes24\",\"name\":\"srcNodeID\",\"type\":\"bytes24\"}],\"name\":\"get\",\"outputs\":[{\"internalType\":\"bytes24\",\"name\":\"dstNodeId\",\"type\":\"bytes24\"},{\"internalType\":\"uint64\",\"name\":\"weight\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"relID\",\"type\":\"bytes4\"},{\"internalType\":\"string\",\"name\":\"relName\",\"type\":\"string\"},{\"internalType\":\"enumWeightKind\",\"name\":\"weightKind\",\"type\":\"uint8\"}],\"name\":\"registerEdgeType\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"kindID\",\"type\":\"bytes4\"},{\"internalType\":\"string\",\"name\":\"kindName\",\"type\":\"string\"},{\"internalType\":\"enumCompoundKeyKind\",\"name\":\"keyKind\",\"type\":\"uint8\"}],\"name\":\"registerNodeType\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"relID\",\"type\":\"bytes4\"},{\"internalType\":\"uint8\",\"name\":\"relKey\",\"type\":\"uint8\"},{\"internalType\":\"bytes24\",\"name\":\"srcNodeID\",\"type\":\"bytes24\"}],\"name\":\"remove\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"relID\",\"type\":\"bytes4\"},{\"internalType\":\"uint8\",\"name\":\"relKey\",\"type\":\"uint8\"},{\"internalType\":\"bytes24\",\"name\":\"srcNodeID\",\"type\":\"bytes24\"},{\"internalType\":\"bytes24\",\"name\":\"dstNodeID\",\"type\":\"bytes24\"},{\"internalType\":\"uint64\",\"name\":\"weight\",\"type\":\"uint64\"}],\"name\":\"set\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes24\",\"name\":\"id\",\"type\":\"bytes24\"},{\"indexed\":false,\"internalType\":\"enumAnnotationKind\",\"name\":\"kind\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"label\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"ref\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"data\",\"type\":\"string\"}],\"name\":\"AnnotationSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes24\",\"name\":\"id\",\"type\":\"bytes24\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"label\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"data\",\"type\":\"bytes32\"}],\"name\":\"DataSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes4\",\"name\":\"relID\",\"type\":\"bytes4\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"relKey\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"bytes24\",\"name\":\"srcNodeID\",\"type\":\"bytes24\"}],\"name\":\"EdgeRemove\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes4\",\"name\":\"relID\",\"type\":\"bytes4\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"relKey\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"bytes24\",\"name\":\"srcNodeID\",\"type\":\"bytes24\"},{\"indexed\":false,\"internalType\":\"bytes24\",\"name\":\"dstNodeID\",\"type\":\"bytes24\"},{\"indexed\":false,\"internalType\":\"uint160\",\"name\":\"weight\",\"type\":\"uint160\"}],\"name\":\"EdgeSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes4\",\"name\":\"id\",\"type\":\"bytes4\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"enumWeightKind\",\"name\":\"kind\",\"type\":\"uint8\"}],\"name\":\"EdgeTypeRegister\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes4\",\"name\":\"id\",\"type\":\"bytes4\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"enumCompoundKeyKind\",\"name\":\"keyKind\",\"type\":\"uint8\"}],\"name\":\"NodeTypeRegister\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"sig\",\"type\":\"bytes\"}],\"name\":\"SeenOpSet\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"bytes24\",\"name\":\"nodeID\",\"type\":\"bytes24\"},{\"internalType\":\"string\",\"name\":\"label\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"annotationData\",\"type\":\"string\"}],\"name\":\"annotate\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"authorizeContract\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"relID\",\"type\":\"bytes4\"},{\"internalType\":\"uint8\",\"name\":\"relKey\",\"type\":\"uint8\"},{\"internalType\":\"bytes24\",\"name\":\"srcNodeID\",\"type\":\"bytes24\"}],\"name\":\"get\",\"outputs\":[{\"internalType\":\"bytes24\",\"name\":\"dstNodeId\",\"type\":\"bytes24\"},{\"internalType\":\"uint64\",\"name\":\"weight\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes24\",\"name\":\"nodeID\",\"type\":\"bytes24\"},{\"internalType\":\"string\",\"name\":\"annotationLabel\",\"type\":\"string\"}],\"name\":\"getData\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"relID\",\"type\":\"bytes4\"},{\"internalType\":\"string\",\"name\":\"relName\",\"type\":\"string\"},{\"internalType\":\"enumWeightKind\",\"name\":\"weightKind\",\"type\":\"uint8\"}],\"name\":\"registerEdgeType\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"kindID\",\"type\":\"bytes4\"},{\"internalType\":\"string\",\"name\":\"kindName\",\"type\":\"string\"},{\"internalType\":\"enumCompoundKeyKind\",\"name\":\"keyKind\",\"type\":\"uint8\"}],\"name\":\"registerNodeType\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"relID\",\"type\":\"bytes4\"},{\"internalType\":\"uint8\",\"name\":\"relKey\",\"type\":\"uint8\"},{\"internalType\":\"bytes24\",\"name\":\"srcNodeID\",\"type\":\"bytes24\"}],\"name\":\"remove\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"relID\",\"type\":\"bytes4\"},{\"internalType\":\"uint8\",\"name\":\"relKey\",\"type\":\"uint8\"},{\"internalType\":\"bytes24\",\"name\":\"srcNodeID\",\"type\":\"bytes24\"},{\"internalType\":\"bytes24\",\"name\":\"dstNodeID\",\"type\":\"bytes24\"},{\"internalType\":\"uint64\",\"name\":\"weight\",\"type\":\"uint64\"}],\"name\":\"set\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes24\",\"name\":\"nodeID\",\"type\":\"bytes24\"},{\"internalType\":\"string\",\"name\":\"label\",\"type\":\"string\"},{\"internalType\":\"bytes32\",\"name\":\"data\",\"type\":\"bytes32\"}],\"name\":\"setData\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
 }
 
 // StateABI is the input ABI used to generate the binding from.
@@ -135,11 +134,11 @@ func NewStateFilterer(address common.Address, filterer bind.ContractFilterer) (*
 
 // bindState binds a generic wrapper to an already deployed contract.
 func bindState(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
-	parsed, err := StateMetaData.GetAbi()
+	parsed, err := abi.JSON(strings.NewReader(StateABI))
 	if err != nil {
 		return nil, err
 	}
-	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
 }
 
 // Call invokes the (constant) contract method with params as input values and
@@ -223,6 +222,37 @@ func (_State *StateCallerSession) Get(relID [4]byte, relKey uint8, srcNodeID [24
 	Weight    uint64
 }, error) {
 	return _State.Contract.Get(&_State.CallOpts, relID, relKey, srcNodeID)
+}
+
+// GetData is a free data retrieval call binding the contract method 0x24eae355.
+//
+// Solidity: function getData(bytes24 nodeID, string annotationLabel) view returns(bytes32)
+func (_State *StateCaller) GetData(opts *bind.CallOpts, nodeID [24]byte, annotationLabel string) ([32]byte, error) {
+	var out []interface{}
+	err := _State.contract.Call(opts, &out, "getData", nodeID, annotationLabel)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// GetData is a free data retrieval call binding the contract method 0x24eae355.
+//
+// Solidity: function getData(bytes24 nodeID, string annotationLabel) view returns(bytes32)
+func (_State *StateSession) GetData(nodeID [24]byte, annotationLabel string) ([32]byte, error) {
+	return _State.Contract.GetData(&_State.CallOpts, nodeID, annotationLabel)
+}
+
+// GetData is a free data retrieval call binding the contract method 0x24eae355.
+//
+// Solidity: function getData(bytes24 nodeID, string annotationLabel) view returns(bytes32)
+func (_State *StateCallerSession) GetData(nodeID [24]byte, annotationLabel string) ([32]byte, error) {
+	return _State.Contract.GetData(&_State.CallOpts, nodeID, annotationLabel)
 }
 
 // Annotate is a paid mutator transaction binding the contract method 0xff271d48.
@@ -349,6 +379,27 @@ func (_State *StateSession) Set(relID [4]byte, relKey uint8, srcNodeID [24]byte,
 // Solidity: function set(bytes4 relID, uint8 relKey, bytes24 srcNodeID, bytes24 dstNodeID, uint64 weight) returns()
 func (_State *StateTransactorSession) Set(relID [4]byte, relKey uint8, srcNodeID [24]byte, dstNodeID [24]byte, weight uint64) (*types.Transaction, error) {
 	return _State.Contract.Set(&_State.TransactOpts, relID, relKey, srcNodeID, dstNodeID, weight)
+}
+
+// SetData is a paid mutator transaction binding the contract method 0x7aaee0d0.
+//
+// Solidity: function setData(bytes24 nodeID, string label, bytes32 data) returns()
+func (_State *StateTransactor) SetData(opts *bind.TransactOpts, nodeID [24]byte, label string, data [32]byte) (*types.Transaction, error) {
+	return _State.contract.Transact(opts, "setData", nodeID, label, data)
+}
+
+// SetData is a paid mutator transaction binding the contract method 0x7aaee0d0.
+//
+// Solidity: function setData(bytes24 nodeID, string label, bytes32 data) returns()
+func (_State *StateSession) SetData(nodeID [24]byte, label string, data [32]byte) (*types.Transaction, error) {
+	return _State.Contract.SetData(&_State.TransactOpts, nodeID, label, data)
+}
+
+// SetData is a paid mutator transaction binding the contract method 0x7aaee0d0.
+//
+// Solidity: function setData(bytes24 nodeID, string label, bytes32 data) returns()
+func (_State *StateTransactorSession) SetData(nodeID [24]byte, label string, data [32]byte) (*types.Transaction, error) {
+	return _State.Contract.SetData(&_State.TransactOpts, nodeID, label, data)
 }
 
 // StateAnnotationSetIterator is returned from FilterAnnotationSet and is used to iterate over the raw logs and unpacked data for AnnotationSet events raised by the State contract.
@@ -483,6 +534,142 @@ func (_State *StateFilterer) WatchAnnotationSet(opts *bind.WatchOpts, sink chan<
 func (_State *StateFilterer) ParseAnnotationSet(log types.Log) (*StateAnnotationSet, error) {
 	event := new(StateAnnotationSet)
 	if err := _State.contract.UnpackLog(event, "AnnotationSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// StateDataSetIterator is returned from FilterDataSet and is used to iterate over the raw logs and unpacked data for DataSet events raised by the State contract.
+type StateDataSetIterator struct {
+	Event *StateDataSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *StateDataSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(StateDataSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(StateDataSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *StateDataSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *StateDataSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// StateDataSet represents a DataSet event raised by the State contract.
+type StateDataSet struct {
+	Id    [24]byte
+	Label string
+	Data  [32]byte
+	Raw   types.Log // Blockchain specific contextual infos
+}
+
+// FilterDataSet is a free log retrieval operation binding the contract event 0x2a5c5e9f907f04c94740d47644d64436febf791f548ed4cc4d42de0c27967fbb.
+//
+// Solidity: event DataSet(bytes24 id, string label, bytes32 data)
+func (_State *StateFilterer) FilterDataSet(opts *bind.FilterOpts) (*StateDataSetIterator, error) {
+
+	logs, sub, err := _State.contract.FilterLogs(opts, "DataSet")
+	if err != nil {
+		return nil, err
+	}
+	return &StateDataSetIterator{contract: _State.contract, event: "DataSet", logs: logs, sub: sub}, nil
+}
+
+// WatchDataSet is a free log subscription operation binding the contract event 0x2a5c5e9f907f04c94740d47644d64436febf791f548ed4cc4d42de0c27967fbb.
+//
+// Solidity: event DataSet(bytes24 id, string label, bytes32 data)
+func (_State *StateFilterer) WatchDataSet(opts *bind.WatchOpts, sink chan<- *StateDataSet) (event.Subscription, error) {
+
+	logs, sub, err := _State.contract.WatchLogs(opts, "DataSet")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(StateDataSet)
+				if err := _State.contract.UnpackLog(event, "DataSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseDataSet is a log parse operation binding the contract event 0x2a5c5e9f907f04c94740d47644d64436febf791f548ed4cc4d42de0c27967fbb.
+//
+// Solidity: event DataSet(bytes24 id, string label, bytes32 data)
+func (_State *StateFilterer) ParseDataSet(log types.Log) (*StateDataSet, error) {
+	event := new(StateDataSet)
+	if err := _State.contract.UnpackLog(event, "DataSet", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log

--- a/services/pkg/sequencer/sequencer.go
+++ b/services/pkg/sequencer/sequencer.go
@@ -273,6 +273,13 @@ func (seqr *MemorySequencer) dispatchSim(
 				Data:  op.AnnData,
 				Raw:   types.Log{BlockNumber: fakeBlockNumber}, // Blockchain specific contextual infos
 			})
+		case 3: // data set
+			opset.Ops = append(opset.Ops, &state.StateDataSet{
+				Id:    op.SrcNodeID,
+				Label: op.AnnName,
+				Data:  op.NodeData,
+				Raw:   types.Log{BlockNumber: fakeBlockNumber}, // Blockchain specific contextual infos
+			})
 		}
 	}
 	seqr.idxr.AddPendingOpSet(int(fakeBlockNumber), opset)

--- a/services/schema/state.graphqls
+++ b/services/schema/state.graphqls
@@ -120,6 +120,12 @@ type Node {
 	annotation(name: String!): Annotation
 
 	"""
+	allData is the store of on-chain 32byte key value pairs belonging to the node
+	"""
+	allData: [NodeData]!
+	data(name: String!): NodeData
+
+	"""
 	nodes have a "kind" label, it is the human friendly decoding of the first 4
 	bytes of the id. See `id` and `keys`. This value is discovered based on the
 	value set on the state contract via registerNodeType.
@@ -277,6 +283,15 @@ usually cost-effective for an equivilent value stored in state.
 type Annotation {
 	id: ID!
 	ref: String!
+	name: String!
+	value: String!
+}
+
+"""
+node data is an on-chain 32byte value stored as a key value pair for a given node
+"""
+type NodeData {
+	id: ID!
 	name: String!
 	value: String!
 }


### PR DESCRIPTION
# What

Added the ability to get/set data on a node by calling `setData` and `getData` on the state object. The data for a node is 32byte key value pairs

```
    function setData(bytes24 nodeID, string memory label, bytes32 data) external;
    function getData(bytes24 nodeID, string memory annotationLabel) external view returns (bytes32);
```

## GraphQL

The data on a node can be queried using graphQL by using the following the fields `data` and `allData`. These work in the same way as annotations where `allData` will give all the data stored on a node and `data` giving you the specific data paired to a given `name` (key)

```
        allData {
          name
          value
        }
        data: data(name: "test") {
          value
        }
```

## Future changes

I'm not sure if `allData` and `data` was a good choice for field names as they aren't consistent with `annotation` and `annotations`. Maybe I should name them `var` and `vars`?

32byte values will work for what we need in Downstream however I think there isn't anything stopping us from mapping the keys to byte arrays i.e. not limiting our data to 32byte values